### PR TITLE
Removed hard-coded serial device path.

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,9 @@ var app        = require('express')();
 var http       = require('http').Server(app);
 var io         = require('socket.io')(http);
 var serialport = require('serialport');
+var exec = require('child_process').exec;
 var SerialPort = serialport.SerialPort;
+var serial;
 
 //When a request come into the server for / give the client the file index.html
 app.get('/', function(req, res){res.sendfile('index.html');});
@@ -11,12 +13,8 @@ app.get('/', function(req, res){res.sendfile('index.html');});
 //Listen for incoming connections
 http.listen(3000, function(){console.log("listening on port 3000");});
 
-//Hook up the serial port
-var serial = new SerialPort( '/dev/cu.usbmodem1411',
-														{parser: serialport.parsers.readline('\n')});
-
 //When the serial port is successfully opened...
-serial.on('open', function()
+var onSerialOpen = function()
 {
 	console.log("opened serial port");
 	//When we get data from the serial port...
@@ -28,8 +26,7 @@ serial.on('open', function()
 		io.emit('to browser', data);
 	});
 
-});
-
+};
 
 //Here's what happens when a connection is made from the browser
 io.sockets.on('connection',
@@ -41,7 +38,7 @@ io.sockets.on('connection',
 		// from the browser
 		socket.on('to serial', function(data)
 		{
-			if(serial.isOpen())
+			if(serial && serial.isOpen())
 			{
 				serial.write(data + '\n');
 				console.log("Send '" + data + "' to serial");
@@ -51,3 +48,14 @@ io.sockets.on('connection',
 		});
 	}
 );
+
+exec('particle serial list', function(error, stdout, stderr) {
+  var devName = stdout.split('\n')[1].split(' - ')[0];
+  console.log(devName);
+
+  //Hook up the serial port
+  serial = new SerialPort( devName,
+														{parser: serialport.parsers.readline('\n')});
+  //When the serial port is successfully opened...
+  serial.on('open', onSerialOpen);
+});

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ var SerialPort = serialport.SerialPort;
 var serial;
 
 //When a request come into the server for / give the client the file index.html
-app.get('/', function(req, res){res.sendfile('index.html');});
+app.get('/', function(req, res){res.sendFile('./index.html', { root: __dirname});});
 
 //Listen for incoming connections
 http.listen(3000, function(){console.log("listening on port 3000");});


### PR DESCRIPTION
Different platforms create the serial device using different paths, e.g. `/dev/cu.usbmodem1411` on Mac or `/dev/ttyACM1` on Ubuntu. This implementation uses particle-cli to get the list of devices.
